### PR TITLE
+= line numbers in release build to allow stepping

### DIFF
--- a/src/07-registers/Cargo.toml
+++ b/src/07-registers/Cargo.toml
@@ -4,5 +4,8 @@ edition = "2018"
 name = "registers"
 version = "0.1.0"
 
+[profile.release]
+debug=1
+
 [dependencies]
 aux7 = { path = "auxiliary" }


### PR DESCRIPTION
[Section 7.2](https://docs.rust-embedded.org/discovery/07-registers/optimization.html) cannot be reproduced with the provided files as line numbers are missing in release build.

This change adds them by modifying the release profile.